### PR TITLE
Send available location data

### DIFF
--- a/app/src/main/java/org/traccar/client/DatabaseHelper.java
+++ b/app/src/main/java/org/traccar/client/DatabaseHelper.java
@@ -96,10 +96,18 @@ public class DatabaseHelper extends SQLiteOpenHelper {
         values.put("time", position.getTime().getTime());
         values.put("latitude", position.getLatitude());
         values.put("longitude", position.getLongitude());
-        values.put("altitude", position.getAltitude());
-        values.put("speed", position.getSpeed());
-        values.put("course", position.getCourse());
-        values.put("accuracy", position.getAccuracy());
+        if (position.getAltitude() != null) {
+            values.put("altitude", position.getAltitude());
+        }
+        if (position.getSpeed() != null) {
+            values.put("speed", position.getSpeed());
+        }
+        if (position.getCourse() != null) {
+            values.put("course", position.getCourse());
+        }
+        if (position.getAccuracy() != null) {
+            values.put("accuracy", position.getAccuracy());
+        }
         values.put("battery", position.getBattery());
         values.put("mock", position.getMock() ? 1 : 0);
 
@@ -130,10 +138,18 @@ public class DatabaseHelper extends SQLiteOpenHelper {
                 position.setTime(new Date(cursor.getLong(cursor.getColumnIndex("time"))));
                 position.setLatitude(cursor.getDouble(cursor.getColumnIndex("latitude")));
                 position.setLongitude(cursor.getDouble(cursor.getColumnIndex("longitude")));
-                position.setAltitude(cursor.getDouble(cursor.getColumnIndex("altitude")));
-                position.setSpeed(cursor.getDouble(cursor.getColumnIndex("speed")));
-                position.setCourse(cursor.getDouble(cursor.getColumnIndex("course")));
-                position.setAccuracy(cursor.getDouble(cursor.getColumnIndex("accuracy")));
+                if (!cursor.isNull(cursor.getColumnIndex("altitude"))) {
+                    position.setAltitude(cursor.getDouble(cursor.getColumnIndex("altitude")));
+                }
+                if (!cursor.isNull(cursor.getColumnIndex("speed"))) {
+                    position.setSpeed(cursor.getFloat(cursor.getColumnIndex("speed")));
+                }
+                if (!cursor.isNull(cursor.getColumnIndex("course"))) {
+                    position.setCourse(cursor.getFloat(cursor.getColumnIndex("course")));
+                }
+                if (!cursor.isNull(cursor.getColumnIndex("accuracy"))) {
+                    position.setAccuracy(cursor.getFloat(cursor.getColumnIndex("accuracy")));
+                }
                 position.setBattery(cursor.getDouble(cursor.getColumnIndex("battery")));
                 position.setMock(cursor.getInt(cursor.getColumnIndex("mock")) > 0);
 

--- a/app/src/main/java/org/traccar/client/Position.java
+++ b/app/src/main/java/org/traccar/client/Position.java
@@ -16,7 +16,6 @@
 package org.traccar.client;
 
 import android.location.Location;
-import android.location.LocationManager;
 import android.os.Build;
 
 import java.util.Date;
@@ -31,10 +30,16 @@ public class Position {
         time = new Date(location.getTime());
         latitude = location.getLatitude();
         longitude = location.getLongitude();
-        altitude = location.getAltitude();
-        speed = location.getSpeed() * 1.943844; // speed in knots
-        course = location.getBearing();
-        if (location.getProvider() != null && !location.getProvider().equals(LocationManager.GPS_PROVIDER)) {
+        if (location.hasAltitude()) {
+            altitude = location.getAltitude();
+        }
+        if (location.hasSpeed()) {
+            speed = location.getSpeed() * 1.943844F; // speed in knots
+        }
+        if (location.hasBearing()) {
+            course = location.getBearing();
+        }
+        if (location.hasAccuracy()) {
             accuracy = location.getAccuracy();
         }
         this.battery = battery;
@@ -93,9 +98,9 @@ public class Position {
         this.longitude = longitude;
     }
 
-    private double altitude;
+    private Double altitude;
 
-    public double getAltitude() {
+    public Double getAltitude() {
         return altitude;
     }
 
@@ -103,33 +108,33 @@ public class Position {
         this.altitude = altitude;
     }
 
-    private double speed;
+    private Float speed;
 
-    public double getSpeed() {
+    public Float getSpeed() {
         return speed;
     }
 
-    public void setSpeed(double speed) {
+    public void setSpeed(float speed) {
         this.speed = speed;
     }
 
-    private double course;
+    private Float course;
 
-    public double getCourse() {
+    public Float getCourse() {
         return course;
     }
 
-    public void setCourse(double course) {
+    public void setCourse(float course) {
         this.course = course;
     }
 
-    private double accuracy;
+    private Float accuracy;
 
-    public double getAccuracy() {
+    public Float getAccuracy() {
         return accuracy;
     }
 
-    public void setAccuracy(double accuracy) {
+    public void setAccuracy(float accuracy) {
         this.accuracy = accuracy;
     }
 

--- a/app/src/main/java/org/traccar/client/ProtocolFormatter.java
+++ b/app/src/main/java/org/traccar/client/ProtocolFormatter.java
@@ -30,11 +30,23 @@ public class ProtocolFormatter {
                 .appendQueryParameter("timestamp", String.valueOf(position.getTime().getTime() / 1000))
                 .appendQueryParameter("lat", String.valueOf(position.getLatitude()))
                 .appendQueryParameter("lon", String.valueOf(position.getLongitude()))
-                .appendQueryParameter("speed", String.valueOf(position.getSpeed()))
-                .appendQueryParameter("bearing", String.valueOf(position.getCourse()))
-                .appendQueryParameter("altitude", String.valueOf(position.getAltitude()))
-                .appendQueryParameter("accuracy", String.valueOf(position.getAccuracy()))
                 .appendQueryParameter("batt", String.valueOf(position.getBattery()));
+
+        if (position.getSpeed() != null) {
+            builder.appendQueryParameter("speed", String.valueOf(position.getSpeed()));
+        }
+
+        if (position.getCourse() != null) {
+            builder.appendQueryParameter("bearing", String.valueOf(position.getCourse()));
+        }
+
+        if (position.getAltitude() != null) {
+            builder.appendQueryParameter("altitude", String.valueOf(position.getAltitude()));
+        }
+
+        if (position.getAccuracy() != null) {
+            builder.appendQueryParameter("accuracy", String.valueOf(position.getAccuracy()));
+        }
 
         if (position.getMock()) {
             builder.appendQueryParameter("mock", String.valueOf(position.getMock()));


### PR DESCRIPTION
When using network or mock location providers, some data might not be available:

* Altitude
* Speed
* Bearing
* Accuracy

We just send available data, hopefully fixing "constantly North-oriented markers" if there's no bearing