### PR TITLE
Implement functionality to capture a config-link and react on it

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -38,6 +38,14 @@
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
+            <intent-filter android:autoVerify="true">
+                <action android:name="android.intent.action.VIEW"/>
+                <category android:name="android.intent.category.DEFAULT"/>
+                <category android:name="android.intent.category.BROWSABLE"/>
+                <data android:host="www.example.org"
+                      android:pathPrefix="/config"
+                      android:scheme="https"/>
+            </intent-filter>
             <meta-data
                 android:name="android.app.shortcuts"
                 android:resource="@xml/shortcuts" />

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -43,4 +43,8 @@
   <string name="hidden_app_name">Geräteeinstellungen</string>
   <string name="hidden_alert">Die App wurde versteckt. Um sie wieder zu öffnen, wähle 8722227 (TRACCAR).</string>
   <string name="error_msg_invalid_url">Bitte eine gültige http:// oder https:// URL eingeben</string>
+    <string name="dialog_title_settings_request">Einstellungen aktualisieren</string>
+  <string name="dialog_msg_announce">Diese Einstellungen werden neu gesetzt:</string>
+  <string name="ok_settings_written">Neue Einstellungen übernommen.</string>
+  <string name="settings_identical">Einstellungen nicht übernommen, identisch mit vorhandenen.</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -47,4 +47,5 @@
   <string name="dialog_title_settings_request">Settings write request</string>
   <string name="dialog_msg_announce">These settings will be written:</string>
   <string name="ok_settings_written">New settings have been written.</string>
+    <string name="settings_identical">Settings not written, identical to existing ones.</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -44,4 +44,7 @@
   <string name="hidden_app_name">Device Settings</string>
   <string name="hidden_alert">The app has been hidden. To open it again please dial 8722227 (TRACCAR).</string>
   <string name="error_msg_invalid_url">Please enter a valid http:// or https:// URL</string>
+  <string name="dialog_title_settings_request">Settings write request</string>
+  <string name="dialog_msg_announce">These settings will be written:</string>
+  <string name="ok_settings_written">New settings have been written.</string>
 </resources>


### PR DESCRIPTION
It has been requested that an Android Traccar-client can be configured remotely, see #355.

@stefanb has had the idea of an Android App Link which carries config-data and opens the Traccar-client directly and shows/requests a new configuration, in order to free the user of bothering about settings.

My solution doesn't use an App Link, but it reacts on a deep link like "https://www.example.org/config/?url=https://receiving.server.com/receive.php&id=12345&interval=120&accuracy=high" if Traccar is installed (and not running). Otherwise the device opens the link in a browser and shows install directions.

Every distributing developer has to customize the intent-filter in AndroidManifest.xml to get a match for their config-link, or if not: no harm is done, the remote-configuring is never triggered.

Request for comments / corrections.